### PR TITLE
rtx: removing payloadType from rtx

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -397,7 +397,6 @@ SDPUtils.parseRtpEncodingParameters = function(mediaSection) {
         ssrc: primarySsrc,
         codecPayloadType: parseInt(codec.parameters.apt, 10),
         rtx: {
-          payloadType: codec.payloadType,
           ssrc: secondarySsrc
         }
       };

--- a/test/sdp.js
+++ b/test/sdp.js
@@ -140,7 +140,6 @@ test('parseRtpEncodingParameters', function(t) {
 
   t.ok(data[0].ssrc === 1734522595, 'parsed primary SSRC');
   t.ok(data[0].rtx, 'has RTX encoding');
-  t.ok(data[0].rtx.payloadType === 96, 'parsed rtx payloadType');
   t.ok(data[0].rtx.ssrc === 2715962409, 'parsed secondary SSRC for RTX');
   t.end();
 });


### PR DESCRIPTION
payloadType is not in the spec here:
    http://draft.ortc.org/#dom-rtcrtprtxparameters