### PR TITLE
Modify parsing of a=fingerprint to cater for Edge browser issue

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -233,10 +233,11 @@ SDPUtils.getDtlsParameters = function(mediaSection, sessionpart) {
     return line.indexOf('a=fingerprint:') === 0;
   })[0].substr(14);
   // Note: a=setup line is ignored since we use the 'auto' role.
+  // Note2: 'algorithm' is not case sensitive except in Edge.
   var dtlsParameters = {
     role: 'auto',
     fingerprints: [{
-      algorithm: fpLine.split(' ')[0],
+      algorithm: fpLine.split(' ')[0].toLowerCase(),
       value: fpLine.split(' ')[1]
     }]
   };


### PR DESCRIPTION
As mentioned here: https://github.com/webrtc/adapter/pull/465

It is easier to cater for the Edge browser issue here than making more complicated changes in adapter.js itself.

I am fairly confident that this has no impact on other browser shims in adapter.js