### PR TITLE
parseCandidate: return integer component

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -48,7 +48,7 @@ SDPUtils.parseCandidate = function(line) {
 
   var candidate = {
     foundation: parts[0],
-    component: parts[1],
+    component: parseInt(parts[1], 10),
     protocol: parts[2].toLowerCase(),
     priority: parseInt(parts[3], 10),
     ip: parts[4],

--- a/test/sdp.js
+++ b/test/sdp.js
@@ -281,7 +281,7 @@ test('parseCandidate', function(t) {
   var candidate = SDPUtils.parseCandidate(candidateString);
 
   t.ok(candidate.foundation === '702786350', 'parsed foundation');
-  t.ok(candidate.component ===  '2', 'parsed component');
+  t.ok(candidate.component ===  2, 'parsed component');
   t.ok(candidate.priority === 41819902, 'parsed priority');
   t.ok(candidate.ip === '8.8.8.8', 'parsed ip');
   t.ok(candidate.protocol === 'udp', 'parsed protocol');


### PR DESCRIPTION
returns the integer component from parseCandidate instead of
a string.

Breaking change.