### PR TITLE
test: increase coverage of ice candidate

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -100,6 +100,10 @@ SDPUtils.writeCandidate = function(candidate) {
     sdp.push('tcptype');
     sdp.push(candidate.tcpType);
   }
+  if (candidate.ufrag) {
+    sdp.push('ufrag');
+    sdp.push(candidate.ufrag);
+  }
   return 'candidate:' + sdp.join(' ');
 };
 


### PR DESCRIPTION
also adds serialization of ufrag shown by tests.

istanbul coverage before:
    63.93% Statements 179/280 50.81% Branches 63/124 67.27% Functions 37/55 63.93% Lines 179/280
and after:
    71.38% Statements 202/283 59.52% Branches 75/126 69.09% Functions 38/55 71.38% Lines 202/283