### PR TITLE
test: generate coverage reports with nyc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+.nyc_output/
+coverage/

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "git+https://github.com/fippo/sdp.git"
   },
   "scripts": {
-    "test": "eslint sdp.js test/sdp.js && mocha test/sdp.js"
+    "test": "eslint sdp.js test/sdp.js && nyc --reporter html mocha test/sdp.js"
   },
   "keywords": [
     "sdp",
@@ -20,6 +20,7 @@
     "chai": "^4.0.0",
     "eslint": "^2.8.0",
     "mocha": "^3.4.2",
+    "nyc": "^10.3.2",
     "sinon": "^2.3.2",
     "sinon-chai": "^2.10.0"
   }


### PR DESCRIPTION
uses nyc to generate nice HTML coverage reports for the tests.