### PR TITLE
sdp: fix handling of b=AS unknown b= modifier

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -449,7 +449,11 @@ SDPUtils.parseRtpEncodingParameters = function(mediaSection) {
     if (bandwidth[0].indexOf('b=TIAS:') === 0) {
       bandwidth = parseInt(bandwidth[0].substr(7), 10);
     } else if (bandwidth[0].indexOf('b=AS:') === 0) {
-      bandwidth = parseInt(bandwidth[0].substr(5), 10);
+      // use formula from JSEP to convert b=AS to TIAS value.
+      bandwidth = parseInt(bandwidth[0].substr(5), 10) * 1000 * 0.95
+          - (50 * 40 * 8);
+    } else {
+      bandwidth = undefined;
     }
     encodingParameters.forEach(function(params) {
       params.maxBitrate = bandwidth;

--- a/test/sdp.js
+++ b/test/sdp.js
@@ -251,24 +251,35 @@ describe('parseRtpEncodingParameters', () => {
     expect(data[0].ssrc).to.equal(98927270);
   });
 
-  it('parses b=AS', () => {
-    sections = SDPUtils.splitSections(
-        videoSDP.replace('c=IN IP4 0.0.0.0\r\n',
-                         'c=IN IP4 0.0.0.0\r\nb=AS:512\r\n')
-    );
-    data = SDPUtils.parseRtpEncodingParameters(sections[1]);
+  describe('bandwidth modifier', () => {
+    it('of type AS is parsed', () => {
+      sections = SDPUtils.splitSections(
+          videoSDP.replace('c=IN IP4 0.0.0.0\r\n',
+                           'c=IN IP4 0.0.0.0\r\nb=AS:512\r\n')
+      );
+      data = SDPUtils.parseRtpEncodingParameters(sections[1]);
 
-    expect(data[0].maxBitrate).to.equal(512);
-  });
+      // conversion formula from jsep.
+      expect(data[0].maxBitrate).to.equal(512 * 1000 * 0.95 - (50 * 40 * 8))
+    });
 
-  it('parses b=TIAS', () => {
-    sections = SDPUtils.splitSections(
-        videoSDP.replace('c=IN IP4 0.0.0.0\r\n',
-                         'c=IN IP4 0.0.0.0\r\nb=TIAS:512000\r\n')
-    );
-    data = SDPUtils.parseRtpEncodingParameters(sections[1]);
+    it('of type TIAS is parsed', () => {
+      sections = SDPUtils.splitSections(
+          videoSDP.replace('c=IN IP4 0.0.0.0\r\n',
+                           'c=IN IP4 0.0.0.0\r\nb=TIAS:512000\r\n')
+      );
+      data = SDPUtils.parseRtpEncodingParameters(sections[1]);
+      expect(data[0].maxBitrate).to.equal(512000);
+    });
 
-    expect(data[0].maxBitrate).to.equal(512000);
+    it('of unknown type is ignored', () => {
+      sections = SDPUtils.splitSections(
+          videoSDP.replace('c=IN IP4 0.0.0.0\r\n',
+                           'c=IN IP4 0.0.0.0\r\nb=something:1\r\n')
+      );
+      data = SDPUtils.parseRtpEncodingParameters(sections[1]);
+      expect(data[0].maxBitrate).to.equal(undefined);
+    });
   });
 });
 


### PR DESCRIPTION
uses JSEP formula to convert b=AS to TIAS value used by ORTC.
Adds tests. Yay coverage branch reports which showed that
parsing an unknown b= modifier resulted in garbage.

Fixes #18