### PR TITLE
Add session ID generation

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -517,10 +517,10 @@ SDPUtils.parseMsid = function(mediaSection) {
   }
 };
 
-// Generate a session ID for SDP.  There is a suggestion
-// in the RFC to use NTP timestamp, but as long as it's unlikely
-// to conflict we should be OK.
-// TODO: use UUIDs instead? https://gist.github.com/jed/982883
+// Generate a session ID for SDP.
+// https://tools.ietf.org/html/draft-ietf-rtcweb-jsep-20#section-5.2.1
+// recommends using a cryptographically random +ve 64-bit value
+// but right now this should be acceptable and within the right range
 SDPUtils.generateSessionId = function() {
   return Math.random().toString().substr(2, 21);
 };

--- a/sdp.js
+++ b/sdp.js
@@ -517,10 +517,27 @@ SDPUtils.parseMsid = function(mediaSection) {
   }
 };
 
-SDPUtils.writeSessionBoilerplate = function() {
+// Generate a session ID for SDP.  There is a suggestion
+// in the RFC to use NTP timestamp, but as long as it's unlikely
+// to conflict we should be OK.
+// TODO: use UUIDs instead? https://gist.github.com/jed/982883
+SDPUtils.generateSessionId = function() {
+  return Math.random().toString().substr(2, 21);
+};
+
+// Write boilder plate for start of SDP
+// sessId argument is optional - if not supplied it will
+// be generated randomly
+SDPUtils.writeSessionBoilerplate = function(sessId) {
+  var sessionId;
+  if (sessId) {
+    sessionId = sessId;
+  } else {
+    sessionId = SDPUtils.generateSessionId();
+  }
   // FIXME: sess-id should be an NTP timestamp.
   return 'v=0\r\n' +
-      'o=thisisadapterortc 8169639915646943137 2 IN IP4 127.0.0.1\r\n' +
+      'o=thisisadapterortc ' + sessionId + ' 2 IN IP4 127.0.0.1\r\n' +
       's=-\r\n' +
       't=0 0\r\n';
 };

--- a/test/sdp.js
+++ b/test/sdp.js
@@ -736,4 +736,14 @@ describe('writeBoilerPlate', () => {
   it('returns a string', () => {
     expect(sdp).to.be.a('String');
   });
+
+  it('generates unique id', () => {
+    expect(sdp).to.not.equal(SDPUtils.writeSessionBoilerplate());
+  });
+
+  it('uses passed in session id', () => {
+    let sessionId = 'uniqueTestSessionId1';
+    let sdpWithSession = SDPUtils.writeSessionBoilerplate(sessionId);
+    expect(sdpWithSession).to.include(' ' + sessionId + ' ');
+  });
 });


### PR DESCRIPTION
This change should generally be compatible with previous versions.  It's just adjusts the session IDs since some code expects the SDP to use a specific session ID (used in adapter.js).