### PR TITLE
sdp: allow non-module inclusion

### DIFF
--- a/sdp.js
+++ b/sdp.js
@@ -645,4 +645,6 @@ SDPUtils.parseMLine = function(mediaSection) {
 };
 
 // Expose public methods.
-module.exports = SDPUtils;
+if (typeof module === 'object') {
+  module.exports = SDPUtils;
+}


### PR DESCRIPTION
allows non-module incluѕion, this will be exposed as window.SDPUtils